### PR TITLE
Change website background path

### DIFF
--- a/src/ColorTheme.js
+++ b/src/ColorTheme.js
@@ -60,7 +60,7 @@ const colorsDark = {
   },
 
   landing: {
-    bg: "url('static/replot_cover_bg.png')",
+    bg: "url('static/img/replot_cover_bg.png')",
   },
 
   getStartedButton: {


### PR DESCRIPTION
Update the dark theme background image path to be 'static/image/...' so we can keep all replot images in the 'image' directory.
@sanjaypojo